### PR TITLE
add submodule: proot-src-by-termux

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "proot-src"]
 	path = proot-src
 	url = git@github.com:cedric-vincent/PRoot.git
+[submodule "proot-src-by-termux"]
+	path = proot-src-by-termux
+	url = https://github.com/termux/proot.git


### PR DESCRIPTION
added proot source of termux's to fix the problem which prevent running apt-get on Android 6.0 or later devices by using link2symlink extension.

I tried running a proot binary which was built by _z80oolong_ on my XPERIA Z5(Android 6.0), apt-get was running successfully. 